### PR TITLE
remove observedAttributes and attributeChangedCallback in Provider

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -21,12 +21,6 @@ export const createProvider = (
   identifier = Symbol(`provider-${Date.now()}`),
 ) => {
   class Provider extends HTMLElement {
-    // TODO FIX: why this is not working?
-    static get observedAttributes() {
-      return ['value'];
-    }
-
-    // TODO: remove get and setter when fixed observedAttributes
     set value(value) {
       values.set(this, value);
       this.notifyChanges();
@@ -48,12 +42,6 @@ export const createProvider = (
 
     static valueOf(context) {
       return valueOf(identifier, context);
-    }
-
-    attributeChangedCallback(name) {
-      if (name === 'value') {
-        this.notifyChanges();
-      }
     }
 
     notifyChanges() {


### PR DESCRIPTION
Hi,

I'm using your library in a component (not publicly available yet) and I've found this TODO comment. I think the reason why it is not working is because you always set the property `value` in the provider instead of the attribute. I think this is convenient since setting the attribute would require to parse the string value, so I've removed the methods related to attributes. 

I'm also thinking in two more changes:
- Removing the support to extend native elements. It's not supported in some browsers like Safari.
- Adding a note about the need to use a polyfill for constructible stylesheets in browsers that don't support them. (https://www.npmjs.com/package/construct-style-sheets-polyfill)

What do you think? Please, let me know if any additional change is required to approve and merge the PR.

Thank you!